### PR TITLE
Use warnings instead of erroring out for invalid field types

### DIFF
--- a/import-csv.php
+++ b/import-csv.php
@@ -293,7 +293,7 @@ class ImportCSV_Command extends WP_CLI_Command {
 
 		$this->_read();
 
-		$blanks = 0;
+		$ok = 0;
 
 		foreach ( $this->csv as $raw_header ) {
 
@@ -314,6 +314,8 @@ class ImportCSV_Command extends WP_CLI_Command {
 			if ( ! isset( $header[ 0 ] ) || ! in_array( $header[ 0 ], array( 'post', 'meta', 'taxonomy', 'thumbnail', 'blank' ) ) ) {
 
 				WP_CLI::warning( $raw_header . ' - ' . $header[ 0 ] . ' is an invalid field type. possible types are meta, post, taxonomy, thumbnail!' );
+
+				$ok++;
 
 				continue;
 
@@ -347,8 +349,10 @@ class ImportCSV_Command extends WP_CLI_Command {
 
 		}
 
+		$csv_count = count( $this->csv );
+		$csv_count -= $ok;
 
-		if ( count( $this->csv ) !== count( $this->headers ) ) {
+		if ( $csv_count !== count( $this->headers ) ) {
 
 			return WP_CLI::error( 'headers are incorrectly formatted, try again!' );
 

--- a/import-csv.php
+++ b/import-csv.php
@@ -313,7 +313,7 @@ class ImportCSV_Command extends WP_CLI_Command {
 
 			if ( ! isset( $header[ 0 ] ) || ! in_array( $header[ 0 ], array( 'post', 'meta', 'taxonomy', 'thumbnail', 'blank' ) ) ) {
 
-				WP_CLI::error( $raw_header . ' - ' . $header[ 0 ] . ' is an invalid field type. possible types are meta, post, taxonomy, thumbnail!' );
+				WP_CLI::warning( $raw_header . ' - ' . $header[ 0 ] . ' is an invalid field type. possible types are meta, post, taxonomy, thumbnail!' );
 
 				continue;
 

--- a/import-csv.php
+++ b/import-csv.php
@@ -293,8 +293,6 @@ class ImportCSV_Command extends WP_CLI_Command {
 
 		$this->_read();
 
-		$ok = 0;
-
 		foreach ( $this->csv as $raw_header ) {
 
 			$header = explode( '-', $raw_header );
@@ -313,11 +311,7 @@ class ImportCSV_Command extends WP_CLI_Command {
 
 			if ( ! isset( $header[ 0 ] ) || ! in_array( $header[ 0 ], array( 'post', 'meta', 'taxonomy', 'thumbnail', 'blank' ) ) ) {
 
-				WP_CLI::warning( $raw_header . ' - ' . $header[ 0 ] . ' is an invalid field type. possible types are meta, post, taxonomy, thumbnail!' );
-
-				$ok++;
-
-				continue;
+				WP_CLI::warning( $raw_header . ' - ' . $header[ 0 ] . ' is an unsupported field type. Possible types are meta, post, taxonomy, thumbnail!' );
 
 			}
 
@@ -349,10 +343,7 @@ class ImportCSV_Command extends WP_CLI_Command {
 
 		}
 
-		$csv_count = count( $this->csv );
-		$csv_count -= $ok;
-
-		if ( $csv_count !== count( $this->headers ) ) {
+		if ( count( $this->csv ) !== count( $this->headers ) ) {
 
 			return WP_CLI::error( 'headers are incorrectly formatted, try again!' );
 


### PR DESCRIPTION
Throw warnings instead of error out for invalid field types, allows for additional things to be done via hooks for extra data