### PR TITLE
Skip post creation when using post ID only

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Example of a header for a field that would contain the post title:
 
     post-wp_kses_post-post_title
 
+If using a previously created post, just specify the post ID:
+
+    post-blank-ID
+
 #### Meta
 
 Meta data is attached to the inserted post using `add_post_meta()`. This example will attach the column of data to post meta data with the key `_home_town`:

--- a/import-csv.php
+++ b/import-csv.php
@@ -59,7 +59,7 @@ class ImportCSV_Command extends WP_CLI_Command {
 
 	/**
 	 * import file data
-	 * @synopsis <file> --post_type=<post> [--author=<author>] [--verbose=<verbose>] [--thumbnail_path=<thumbnail_path>]
+	 * @synopsis <file> [--post_type=<post>] [--author=<author>] [--verbose=<verbose>] [--thumbnail_path=<thumbnail_path>]
 	 * @access public
 	 * @param $args array command arguments
 	 * @param $assoc_args associative command arguments
@@ -82,15 +82,6 @@ class ImportCSV_Command extends WP_CLI_Command {
 		foreach ( $this->data as $k => $v ) {
 
 			if ( isset( $v[ 'post' ] ) ) {
-
-				// All posts need a title,
-				if ( ! isset( $v[ 'post' ][ 'post_title' ][ 'value' ] ) && $v[ 'post' ][ 'post_title' ][ 'value' ] !== '' ) {
-
-					WP_CLI::warning( 'row #' . $k . ' skipped - needs a post title...' );
-
-					continue;
-
-				}
 
 				if ( ! $post_id = $this->_insert( $v[ 'post' ] ) ) {
 
@@ -148,7 +139,7 @@ class ImportCSV_Command extends WP_CLI_Command {
 
 	/**
 	 * Map row data based on csv file headers
-	 * @synopsis <file> --post_type=<post> [--author=<author>] [--verbose=<verbose>] [--thumbnail_path=<thumbnail_path>]
+	 * @synopsis <file> [--post_type=<post>] [--author=<author>] [--verbose=<verbose>] [--thumbnail_path=<thumbnail_path>]
 	 * @access public
 	 * @param $args array command arguments
 	 * @param $assoc_args associative command arguments
@@ -207,7 +198,7 @@ class ImportCSV_Command extends WP_CLI_Command {
 
 	/**
 	 * Checks and reads import file
-	 * @synopsis <file> --post_type=<post> [--author=<author>] [--verbose=<verbose>] [--thumbnail_path=<thumbnail_path>]
+	 * @synopsis <file> [--post_type=<post>] [--author=<author>] [--verbose=<verbose>] [--thumbnail_path=<thumbnail_path>]
 	 * @access public
 	 * @param $args array command arguments
 	 * @param $assoc_args associative command arguments
@@ -280,7 +271,7 @@ class ImportCSV_Command extends WP_CLI_Command {
 
 		} else {
 
-			return WP_CLI::error( $assoc_args[ 'post_type' ] . ' post type does not exist!' );
+			WP_CLI::warning( $assoc_args[ 'post_type' ] . ' post type not specified or does not exist!' );
 
 		}
 
@@ -436,6 +427,20 @@ class ImportCSV_Command extends WP_CLI_Command {
 	 * @return bool true on success
 	 */
 	private function _insert( $post_data ) {
+
+		// Either create a new post or use provided ID
+		if ( count( $post_data ) === 1 && isset( $post_data[ 'ID' ][ 'value' ] ) && $post_data[ 'ID' ][ 'value' ] ) {
+
+			return $post_data[ 'ID' ][ 'value' ];
+
+		} else if ( ! isset( $post_data[ 'post_title' ][ 'value' ] ) && $post_data[ 'post_title' ][ 'value' ] !== '' ) {
+			// All new posts need a title
+
+			WP_CLI::warning( 'row #' . $k . ' skipped - needs a post title...' );
+
+			return false;
+
+		}
 
 		$post[ 'post_title' ] = $post_data[ 'post_title' ];
 


### PR DESCRIPTION
Allows the user to skip new post creation. Helps in updating existing an existing post with new meta, taxonomy, etc.
- Makes post type optional
